### PR TITLE
Fixed browser version not being passed on to the Webdriver

### DIFF
--- a/nose_selenium.py
+++ b/nose_selenium.py
@@ -312,6 +312,7 @@ class NoseSelenium(Plugin):
         BROWSER = options.browser
         TIMEOUT = options.timeout
         BUILD = options.build
+        BROWSER_VERSION = options.browser_version
         OS = options.os
         SAVED_FILES_PATH = options.saved_files_storage
         SAUCE_USERNAME = options.sauce_username


### PR DESCRIPTION
When using nose-selenium with a Selenium grid and specifying the browser version using the --browser-version command line argument, the value entered there doesn't get passed on to the Webdriver.
