### PR TITLE
Fixed missing paths not being created on Windows

### DIFF
--- a/nose_selenium.py
+++ b/nose_selenium.py
@@ -383,7 +383,8 @@ class ScreenshotOnExceptionWebDriverWait(WebDriverWait):
         super(ScreenshotOnExceptionWebDriverWait, self).__init__(*args, **kwargs)
         global SAVED_FILES_PATH
         if SAVED_FILES_PATH:
-            os.system("mkdir -p %s" % SAVED_FILES_PATH)
+          if not os.path.exists(SAVED_FILES_PATH):
+            os.makedirs(SAVED_FILES_PATH)
 
     def until(self, *args, **kwargs):
         try:
@@ -439,7 +440,8 @@ class ScreenshotOnExceptionWebDriver(webdriver.Remote):
         super(ScreenshotOnExceptionWebDriver, self).__init__(*args, **kwargs)
         global SAVED_FILES_PATH
         if SAVED_FILES_PATH:
-            os.system("mkdir -p %s" % SAVED_FILES_PATH)
+          if not os.path.exists(SAVED_FILES_PATH):
+            os.makedirs(SAVED_FILES_PATH)
 
     def execute(self, driver_command, params=None):
         curframe = inspect.currentframe()


### PR DESCRIPTION
nose-selenium used to use os.system to invoke "mkdir -p", which doesn't
work under Windows. Python has its own native implementation of "mkdir
-p" (os.makedirs) with the same functionality, and this native implementation
should work better on all OSes (or at least provide meaningful error traces).
